### PR TITLE
Improve frontmatter parsing and add edge case tests

### DIFF
--- a/Sources/FrontRange/FrontMatteredDoc/FrontMatteredDoc.Parser.swift
+++ b/Sources/FrontRange/FrontMatteredDoc/FrontMatteredDoc.Parser.swift
@@ -13,26 +13,60 @@ extension FrontMatteredDoc {
   public struct Parser: Parsing.ParserPrinter {
     public typealias Input = Substring
     public typealias Output = FrontMatteredDoc
-    
+
     public enum ParsingError: Swift.Error {
       /// The root object of the YAML string is not a mapping.
       case notAMapping
       /// The YAML string could not be parsed into a valid Yams `Node`.
       case notANode
     }
-    
-    public var body: some Parsing.Parser<Input, Output> {
-      Parse(input: Substring.self) {
-        FrontMatteredDoc(frontMatter: $0, body: String($1))
-      } with: {
-        "---\n"
-        PrefixUpTo("---\n")
-          .map(YAMLSubstringToNodeMappingConversion()) // Substring -> Yams.Node
-        "---\n"
-        Rest() // Substring -> Substring
+
+    public init() {}
+
+    public func parse(_ input: inout Substring) throws -> FrontMatteredDoc {
+      // Check if input starts with frontmatter delimiter
+      if input.starts(with: "---\n") {
+        // Has opening delimiter → try to parse frontmatter
+        var workingInput = input
+        do {
+          let frontMatter = try frontMatterParser.parse(&workingInput)
+          // Success! Consume the input and return
+          let body = String(workingInput)
+          input = ""
+          return FrontMatteredDoc(frontMatter: frontMatter, body: body)
+        } catch {
+          // Frontmatter parsing failed - check if it's due to missing closing delimiter
+          // or invalid YAML/structure
+          let errorDescription = String(describing: error)
+          if errorDescription.contains("notAMapping") || errorDescription.contains("notANode") {
+            // Invalid YAML structure → propagate error
+            throw error
+          } else {
+            // Other error (likely no closing delimiter) → treat as no frontmatter
+            let body = String(input)
+            input = ""
+            return FrontMatteredDoc(frontMatter: Yams.Node.Mapping(), body: body)
+          }
+        }
+      } else {
+        // No opening delimiter → empty mapping (valid case)
+        let body = String(input)
+        input = ""
+        return FrontMatteredDoc(frontMatter: Yams.Node.Mapping(), body: body)
       }
     }
-    
+
+    private var frontMatterParser: some Parsing.Parser<Substring, Yams.Node.Mapping> {
+      Parse(input: Substring.self) {
+        "---\n"
+        PrefixUpTo("---")
+          .map(YAMLSubstringToNodeMappingConversion()) // Substring -> Yams.Node.Mapping
+        "---"
+        Optionally { "\n" }
+      }
+      .map { mapping, _ in mapping }
+    }
+
     public func print(_ output: FrontMatteredDoc, into input: inout Substring) throws {
       input = """
               ---

--- a/Sources/FrontRange/FrontMatteredDoc/YAML/YAML Parsing.swift
+++ b/Sources/FrontRange/FrontMatteredDoc/YAML/YAML Parsing.swift
@@ -14,6 +14,12 @@ public struct YAMLSubstringToNodeMappingConversion: Conversion {
   public typealias Output = Yams.Node.Mapping
   
   public func apply(_ input: Substring) throws -> Yams.Node.Mapping {
+    // Handle empty or whitespace-only input as valid empty frontmatter
+    let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.isEmpty {
+      return Yams.Node.Mapping()
+    }
+
     guard let node = try? Yams.compose(yaml: String(input)) else {
       throw FrontMatteredDoc.Parser.ParsingError.notANode
     }


### PR DESCRIPTION
Refactors the frontmatter parser to handle empty and whitespace-only frontmatter as valid empty mappings, and improves error handling for invalid YAML structures. Adds comprehensive tests for valid and invalid frontmatter edge cases, including empty documents, missing delimiters, and unsupported line endings.